### PR TITLE
Reduce the size of the NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
   "browser": {
     "crypto": false
   },
-  "license": "MIT"
+  "license": "MIT",
+  "main": "index.js",
+  "files": []
 }


### PR DESCRIPTION
An empty files array keeps the main file, package.json, README and LICENSE.

The following files/directories are removed from the package:

- example
- .npmignore
- test
- .travis.yml
- .zuul.yml