### PR TITLE
Update repo link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "name": "crypto-browserify",
   "description": "implementation of crypto for the browser",
   "version": "3.12.0",
-  "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+  "homepage": "https://github.com/browserify/crypto-browserify",
   "repository": {
     "type": "git",
-    "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+    "url": "git://github.com/browserify/crypto-browserify.git"
   },
   "scripts": {
     "standard": "standard",


### PR DESCRIPTION
PR updates the link to the repo in the `package.json`, where `https://github.com/crypto-browserify/crypto-browserify` leads to a 404 while `https://github.com/browserify/crypto-browserify` leads here. I discovered this when I went to the [npm page](https://www.npmjs.com/package/crypto-browserify) for the package, clicked for the homepage and got a 404 error.